### PR TITLE
Modified check-ntp.rb to ignore extra line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased][unreleased]
 
+### Fixed
+- Modified check-ntp.rb to ignore additional initial line of ntpq output on some systems (e.g. Centos6)
+
 ## [0.0.2] - 2015-06-03
 
 ### Fixed

--- a/bin/check-ntp.rb
+++ b/bin/check-ntp.rb
@@ -39,7 +39,7 @@ class CheckNTP < Sensu::Plugin::Check::CLI
 
   def run
     begin
-      output = `ntpq -c "rv 0 stratum,offset"`
+      output = `ntpq -c "rv 0 stratum,offset"`.split("\n").find { |line|  line.start_with?('stratum')  }
       stratum = output.split(',')[0].split('=')[1].strip.to_i
       offset = output.split(',')[1].split('=')[1].strip.to_f
     rescue


### PR DESCRIPTION
On some systems (e.g. Centos6), ntpq returns an additional extra line.
e.g.
[root@hostname ~]# ntpq -c "rv 0 stratum,offset"
assID=0 status=06f4 leap_none, sync_ntp, 15 events, event_peer/strat_chg,
stratum=4, offset=-15.450

This change should work with single or multi-line returns
