### PR TITLE
fix args to handle a float, added config option

### DIFF
--- a/bin/check-ntp.rb
+++ b/bin/check-ntp.rb
@@ -22,7 +22,7 @@
 #   Copyright 2012 Sonian, Inc <chefs@sonian.net>
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
-# 
+#
 # Stratum Levels
 # 1:      Primary reference (e.g., calibrated atomic clock, radio clock, etc...)
 # 2-15:   Secondary reference (via NTP, calculated as the stratum of your system peer plus one)
@@ -42,7 +42,7 @@ class CheckNTP < Sensu::Plugin::Check::CLI
          short: '-c CRIT',
          proc: proc(&:to_f),
          default: 100
-  
+
   option :stratum,
          short: '-s STRATUM',
          description: 'check that stratum meets or exceeds desired value',
@@ -57,13 +57,13 @@ class CheckNTP < Sensu::Plugin::Check::CLI
     rescue
       unknown 'NTP command Failed'
     end
-  
+
     if stratum > 15
       critical 'NTP not synced'
     elsif stratum > config[:stratum]
       critical "NTP stratum (#{stratum}) above limit (#{config[:stratum]})"
     end
-    
+
     message = "NTP offset by #{offset.abs}ms"
     critical message if offset >= config[:crit] || offset <= -config[:crit]
     warning message if offset >= config[:warn] || offset <= -config[:warn]

--- a/bin/check-ntp.rb
+++ b/bin/check-ntp.rb
@@ -22,6 +22,12 @@
 #   Copyright 2012 Sonian, Inc <chefs@sonian.net>
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
+# 
+# Stratum Levels
+# 1:      Primary reference (e.g., calibrated atomic clock, radio clock, etc...)
+# 2-15:   Secondary reference (via NTP, calculated as the stratum of your system peer plus one)
+# 16:     Unsynchronized
+# 17-255: Reserved
 #
 
 require 'sensu-plugin/check/cli'
@@ -40,7 +46,8 @@ class CheckNTP < Sensu::Plugin::Check::CLI
     option :stratum,
          short: '-s STRATUM',
          description: 'check that stratum meets or exceeds desired value',
-         proc: proc(&:to_i)
+         proc: proc(&:to_i),
+         default: 15
 
   def run
     begin
@@ -52,11 +59,9 @@ class CheckNTP < Sensu::Plugin::Check::CLI
     end
   
     if stratum > 15
-      critical "NTP not synced"
-    elsif config[:stratum]
-      if stratum > config[:stratum]
-        critical "NTP stratum (#{stratum}) above limit (#{config[:stratum]})"
-      end
+      critical 'NTP not synced'
+    elsif stratum > config[:stratum]
+      critical "NTP stratum (#{stratum}) above limit (#{config[:stratum]})"
     end
     
     message = "NTP offset by #{offset.abs}ms"

--- a/bin/check-ntp.rb
+++ b/bin/check-ntp.rb
@@ -43,7 +43,7 @@ class CheckNTP < Sensu::Plugin::Check::CLI
          proc: proc(&:to_f),
          default: 100
   
-    option :stratum,
+  option :stratum,
          short: '-s STRATUM',
          description: 'check that stratum meets or exceeds desired value',
          proc: proc(&:to_i),


### PR DESCRIPTION
Fix for issue #3 where warning and critical args used int rather than float.  Added arg to have a configurable stratum limit.
