### PR TITLE
Fix interpretation of leap field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- Fixed interpretation of the leap field in check-ntp.rb
 
 ## [1.0.0] - 2016-07-13
 ### Added

--- a/bin/check-ntp.rb
+++ b/bin/check-ntp.rb
@@ -62,7 +62,7 @@ class CheckNTP < Sensu::Plugin::Check::CLI
       output = `ntpq -c "rv 0 stratum,offset"`.split("\n").find { |line| line.start_with?('stratum') }
       stratum = output.split(',')[0].split('=')[1].strip.to_i
       offset = output.split(',')[1].split('=')[1].strip.to_f
-      source_field_status = config[:unsynced_status] == 'ok' ? 6 : /status=[0-3]([0-9])[0-9a-f]{2}/.match(`ntpq -c "rv 0"`)[1].to_i
+      source_field_status = config[:unsynced_status] == 'ok' ? 6 : /status=[0-9a-f]([0-9])[0-9a-f]{2}/.match(`ntpq -c "rv 0"`)[1].to_i
     rescue
       unknown 'NTP command Failed'
     end


### PR DESCRIPTION
The leap field in the ntpd status code is a hex number, composed of the 4 bit flags, not a decimal number between 0 and 3. See https://www.eecis.udel.edu/~mills/ntp/html/decode.html: "The Leap Field displays the system leap indicator bits[...]"
