### PR TITLE
Fix time out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+## Fixed
+- check-ntp.rb: fix timeout issue bu using loopback (@mdzidic)
+
 ### Added
 - Ruby 2.4.1 testing
 

--- a/bin/check-ntp.rb
+++ b/bin/check-ntp.rb
@@ -59,10 +59,10 @@ class CheckNTP < Sensu::Plugin::Check::CLI
 
   def run
     begin
-      output = `ntpq -c "rv 0 stratum,offset"`.split("\n").find { |line| line.start_with?('stratum') }
+      output = `ntpq -c "rv 0 stratum,offset" 127.0.0.1`.split("\n").find { |line| line.start_with?('stratum') }
       stratum = output.split(',')[0].split('=')[1].strip.to_i
       offset = output.split(',')[1].split('=')[1].strip.to_f
-      source_field_status = config[:unsynced_status] == 'ok' ? 6 : /status=[0-9a-f]([0-9])[0-9a-f]{2}/.match(`ntpq -c "rv 0"`)[1].to_i
+      source_field_status = config[:unsynced_status] == 'ok' ? 6 : /status=[0-9a-f]([0-9])[0-9a-f]{2}/.match(`ntpq -c "rv 0" 127.0.0.1`)[1].to_i
     rescue
       unknown 'NTP command Failed'
     end


### PR DESCRIPTION
When there are lots of virtual network interfaces `ntpq` is somehow confused and returns this error:
> localhost: timed out, nothing received
> ***Request timed out CheckNTP UNKNOWN: NTP command Failed

Defining 127.0.0.1 host at end of `ntpq` command fixed this problem.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatability Issues

