### PR TITLE
Add command line option for host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [here](https://github.com/sensu-plug
 ## [Unreleased]
 
 ### Added
+- Command line option for host
 - Updated asset build targets to support centos6
 - Removed centos from bonsai asset definition
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ This plugin provides native network time protocol (NTP) instrumentation for moni
  * metrics-ntpstats.rb
  
 **check-ntp** 
-Checks the synchronization state of the local NTP server.
+Checks the synchronization state of local or remote NTP server.
 
 * Parameters:
+  - `host`: Host name/address (default: `127.0.0.1`)
   - `warn`: Maximum offset in ms for warning state (default: `10`)
   - `crit`: Maximum offset in ms for critical state (default: `100`)
   - `stratum`: Maximum stratum value (default: `15`)
@@ -75,6 +76,7 @@ Gets metrics from `ntpstats`.
 **check-ntp.rb**
 ```
 Usage: check-ntp.rb (options)
+    -h HOST
     -c CRIT
     -s STRATUM                       check that stratum meets or exceeds desired value
     -u CODE                          If ntp_status is unsynced (that is, not yet connected to or disconnected from ntp), what should the response be.


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
_No_

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

_N/A_

#### Purpose

* _Allow checking a remote NTP appliance/server._
* _Also for efficiency, only call `ntpq` once to get all data in `raw` mode._
* _Also improve the hex decode of the `status` variable (to match ntp_decode(5))._

#### Known Compatibility Issues

* _No change in default behavior, still uses localhost._
* _Tested with ntpq on RHEL6 and RHEL7 (ntp-4.2.6p5)._
